### PR TITLE
Remove serde dependency and use lum_libs::serde as serde crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,10 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "lum_config"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "lum_libs",
- "serde",
  "thiserror 2.0.11",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lum_config"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Torben Schweren"]
 edition = "2024"
 rust-version = "1.85.0"
@@ -21,9 +21,6 @@ debug = true
 opt-level = 0
 lto = false
 
-# serde and thiserror have to be a dependency to use their derive macros.
-# In code, we are still importing from lum_libs, but their macros need the respective crate to be present.
 [dependencies]
 lum_libs = "0.2.0"
-serde = { version = "1.0.215", features = ["derive"] }
 thiserror = "2.0.11"

--- a/src/env_handler.rs
+++ b/src/env_handler.rs
@@ -28,6 +28,7 @@ use crate::EnvironmentConfigParseError;
 /// use std::env;
 ///
 /// #[derive(Serialize, Deserialize)]
+/// #[serde(crate = "lum_libs::serde")]
 /// struct Config {
 ///     key: String,
 /// }

--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -30,6 +30,7 @@ use crate::{ConfigPathError, ConfigSaveError, FileConfigParseError};
 /// use std::{env, fs, path::PathBuf};
 ///
 /// #[derive(Serialize, Deserialize)]
+/// #[serde(crate = "lum_libs::serde")]
 /// #[serde(default)]
 /// struct Config {
 ///     key: String,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,6 +13,7 @@ pub static FILE_CONFIG_VALUE_SET: &str = "File config";
 pub static NESTED_CONFIG_VALUE_SET: &str = "Nested config";
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(crate = "lum_libs::serde")]
 #[serde(default)]
 pub struct EnvConfig {
     pub value: Option<String>,
@@ -27,6 +28,7 @@ impl Default for EnvConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(crate = "lum_libs::serde")]
 #[serde(default)]
 pub struct FileConfig {
     pub value: String,
@@ -52,6 +54,7 @@ impl MergeFrom<EnvConfig> for FileConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(crate = "lum_libs::serde")]
 #[serde(default)]
 pub struct NestedConfig {
     pub value: String,


### PR DESCRIPTION
This pull request removes the serde dependency from the project and instead uses the re-exported serde from lum_libs.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the package version from `0.2.0` to `0.2.1` to reflect the new changes.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L24-L28): Removed the `serde` dependency from the `[dependencies]` section.

Serde crate annotations:

* [`src/env_handler.rs`](diffhunk://#diff-f34a815a33c10e2199caf3ed5011d07fc67425c8329dee4c70fa5fed497833deR31): Added `#[serde(crate = "lum_libs::serde")]` to the `Config` struct to specify the serde crate for serialization and deserialization.
* [`src/file_handler.rs`](diffhunk://#diff-a21ea322806725907e35ac65acd162497503e1f75a5448cbdeb3d17fee4c538bR33): Added `#[serde(crate = "lum_libs::serde")]` to the `Config` struct to specify the serde crate for serialization and deserialization.
* [`tests/common/mod.rs`](diffhunk://#diff-b1468398834010878872c40aae02104459a3783161141aab498d30accd861e4cR16): Added `#[serde(crate = "lum_libs::serde")]` to the `EnvConfig`, `FileConfig`, and `NestedConfig` structs to specify the serde crate for serialization and deserialization. [[1]](diffhunk://#diff-b1468398834010878872c40aae02104459a3783161141aab498d30accd861e4cR16) [[2]](diffhunk://#diff-b1468398834010878872c40aae02104459a3783161141aab498d30accd861e4cR31) [[3]](diffhunk://#diff-b1468398834010878872c40aae02104459a3783161141aab498d30accd861e4cR57)